### PR TITLE
Fix Mac Arm64

### DIFF
--- a/lib/src/std/fcntl.dart
+++ b/lib/src/std/fcntl.dart
@@ -29,12 +29,15 @@ mixin StdFcntlMixin on PlatformLibC {
 }
 
 final _fcntlInt = dylib
-    .lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int, ffi.Int, ffi.Int)>>(
-        'fcntl')
+    .lookup<
+        ffi.NativeFunction<
+            ffi.Int Function(
+                ffi.Int, ffi.Int, ffi.VarArgs<(ffi.Int,)>)>>('fcntl')
     .asFunction<int Function(int, int, int)>();
 
 final _fcntlPtr = dylib
     .lookup<
         ffi.NativeFunction<
-            ffi.Int Function(ffi.Int, ffi.Int, ffi.Pointer)>>('fcntl')
+            ffi.Int Function(
+                ffi.Int, ffi.Int, ffi.VarArgs<(ffi.Pointer,)>)>>('fcntl')
     .asFunction<int Function(int, int, ffi.Pointer)>();


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1062

The `VarArgs` should be used for `...` args in C.

https://api.dart.dev/stable/3.3.3/dart-ffi/VarArgs-class.html