### PR TITLE
Fix a bug where the wrong time was used for `st_birthtim` on Linux

### DIFF
--- a/lib/src/gnu/stat.dart
+++ b/lib/src/gnu/stat.dart
@@ -53,7 +53,6 @@ extension GnuStat on ffi.Pointer<ffi.stat_t> {
       st_atim: ref.st_atim.toDateTime(),
       st_mtim: ref.st_mtim.toDateTime(),
       st_ctim: ref.st_ctim.toDateTime(),
-      st_birthtim: ref.st_ctim.toDateTime(),
     );
   }
 }

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -67,15 +67,15 @@ class Stat {
   /// Time of last modification
   ///
   /// May be the date of the Unix epoch
-  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
-  /// not meaningful for the file (e.g. stdin).
+  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file modification time
+  /// is not meaningful for the file (e.g. stdin).
   final DateTime st_mtim;
 
   /// Time of last status change.
   ///
   /// May be the date of the Unix epoch
-  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
-  /// not meaningful for the file (e.g. stdin).
+  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file last status change
+  /// time is not meaningful for the file (e.g. stdin).
   final DateTime st_ctim;
 
   /// Time when the file was created.

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -27,7 +27,7 @@ class Stat {
     required this.st_atim,
     required this.st_mtim,
     required this.st_ctim,
-    required this.st_birthtim,
+    this.st_birthtim,
     this.st_flags,
   });
 
@@ -65,13 +65,27 @@ class Stat {
   final DateTime st_atim;
 
   /// Time of last modification
+  ///
+  /// May return the date of the Unix epoch
+  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
+  /// not meaningful for the file (e.g. stdin).
   final DateTime st_mtim;
 
-  /// Time of last status change
+  /// Time of last status change.
+  ///
+  /// May return the date of the Unix epoch
+  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
+  /// not meaningful for the file (e.g. stdin).
   final DateTime st_ctim;
 
-  /// Time when the file was created
-  final DateTime st_birthtim;
+  /// Time when the file was created.
+  ///
+  /// May return the date of the Unix epoch
+  /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
+  /// not meaningful for the file (e.g. stdin).
+  ///
+  /// Only available on macOS.
+  final DateTime? st_birthtim;
 
   /// User defined flags
   ///

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -66,21 +66,21 @@ class Stat {
 
   /// Time of last modification
   ///
-  /// May return the date of the Unix epoch
+  /// May be the date of the Unix epoch
   /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
   /// not meaningful for the file (e.g. stdin).
   final DateTime st_mtim;
 
   /// Time of last status change.
   ///
-  /// May return the date of the Unix epoch
+  /// May be the date of the Unix epoch
   /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
   /// not meaningful for the file (e.g. stdin).
   final DateTime st_ctim;
 
   /// Time when the file was created.
   ///
-  /// May return the date of the Unix epoch
+  /// May be the date of the Unix epoch
   /// (`DateTime.fromMicrosecondsSinceEpoch(0)`) if the file creation time is
   /// not meaningful for the file (e.g. stdin).
   ///

--- a/test/stat_test.dart
+++ b/test/stat_test.dart
@@ -23,6 +23,7 @@ void main() {
     expect(actual.st_atim, isTime(expected.accessed));
     expect(actual.st_mtim, isTime(expected.modified));
     expect(actual.st_ctim, isTime(expected.changed));
+    expect(actual.st_birthtim, Platform.isMacOS ? isNotNull : isNull);
     expect(actual.st_flags, Platform.isMacOS ? isNotNull : isNull);
   });
 
@@ -40,7 +41,7 @@ void main() {
     expect(actual.st_blocks, isNonNegative);
     expect(actual.st_atim, anyOf(isEpoch, isRecent));
     expect(actual.st_mtim, anyOf(isEpoch, isRecent));
-    expect(actual.st_birthtim, anyOf(isEpoch, isRecent));
+    expect(actual.st_birthtim, Platform.isMacOS ? isEpoch : isNull);
     expect(actual.st_flags, Platform.isMacOS ? isNotNull : isNull);
   });
 
@@ -67,7 +68,7 @@ void main() {
     expect(actual.st_atim, isRecent);
     expect(actual.st_mtim, isRecent);
     expect(actual.st_ctim, isRecent);
-    expect(actual.st_birthtim, isRecent);
+    expect(actual.st_birthtim, Platform.isMacOS ? isRecent : isNull);
     expect(actual.st_flags, Platform.isMacOS ? isNotNull : isNull);
   });
 


### PR DESCRIPTION
Changed `st_birthtim` to be nullable and be `null` on Linux.

Added documentation explaining that the epoch would be returned for time fields if the time is not meaningful for the file.